### PR TITLE
Use failure crate for errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wikipedia"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Sebastian Waisbrot <seppo0010@gmail.com>"]
 license-file = "LICENSE"
 
@@ -19,3 +19,4 @@ http-client = ["reqwest", "url"]
 serde_json = "1.0.8"
 reqwest = { version = "0.8.1", optional = true }
 url = { version = "1.6.0", optional = true }
+failure = "0.1.1"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The crate is called `wikipedia` and you can depend on it via cargo:
 
 ```toml
 [dependencies]
-wikipedia = "0.3.0"
+wikipedia = "0.3.1"
 ```
 
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,5 +1,4 @@
-#[derive(Debug)]
-pub struct Error;
+pub use failure::Error;
 
 pub trait HttpClient {
     fn user_agent(&mut self, user_agent: String);
@@ -9,12 +8,9 @@ pub trait HttpClient {
 
 #[cfg(feature="http-client")]
 pub mod default {
-    use std::convert;
-    use std::io;
     use std::io::Read;
-
     use reqwest;
-    use url;
+    use failure::err_msg;
 
     use super::{Error, HttpClient};
 
@@ -41,31 +37,11 @@ pub mod default {
                 .header(reqwest::header::UserAgent::new(self.user_agent.clone()))
                 .send()?;
 
-            if !response.status().is_success() {
-                return Err(Error);
-            }
+            ensure!(response.status().is_success(), err_msg("Bad status"));
 
             let mut response_str = String::new();
             response.read_to_string(&mut response_str)?;
             Ok(response_str)
-        }
-    }
-
-    impl convert::From<reqwest::Error> for Error {
-        fn from(_: reqwest::Error) -> Self {
-            Error
-        }
-    }
-
-    impl convert::From<url::ParseError> for Error {
-        fn from(_: url::ParseError) -> Self {
-            Error
-        }
-    }
-
-    impl convert::From<io::Error> for Error {
-        fn from(_: io::Error) -> Self {
-            Error
         }
     }
 }


### PR DESCRIPTION
Use failure crate for errors (which is aiming to be a new standard of error handling in Rust [*])

* https://boats.gitlab.io/blog/post/2017-11-16-announcing-failure/