### PR TITLE
Add language link iterator to page

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -150,6 +150,31 @@ impl IterItem for Link {
 }
 
 #[derive(Debug, PartialEq)]
+pub struct LangLink {
+    /// The language ID
+    pub lang: String,
+
+    /// The page title in this language, may be `None` if undefined
+    pub title: Option<String>,
+}
+
+impl IterItem for LangLink {
+    fn request_next<A: http::HttpClient>(page: &Page<A>, cont: &Option<Vec<(String, String)>>)
+            -> Result<(Vec<Value>, Option<Vec<(String, String)>>)> {
+        page.request_langlinks(&cont)
+    }
+
+    fn from_value(value: &Value) -> Option<LangLink> {
+        value
+            .as_object()
+            .map(|l| LangLink {
+                lang: l.get("lang").unwrap().as_str().unwrap().into(),
+                title: l.get("*").and_then(|n| n.as_str()).map(|n| n.into()),
+            })
+    }
+}
+
+#[derive(Debug, PartialEq)]
 pub struct Category {
     pub title: String,
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -169,6 +169,32 @@ mod tests {
     }
 
     #[test]
+    fn langlinks() {
+        let mut wikipedia = w();
+        wikipedia.links_results = "3".to_owned();
+        let page = wikipedia.page_from_title("Law of triviality".to_owned());
+        let langlinks = page.get_langlinks().unwrap().collect::<Vec<_>>();
+        assert_eq!(
+            langlinks
+                .iter()
+                .filter(|ll| ll.lang == "nl".to_owned())
+                .next()
+                .unwrap()
+                .title,
+            Some("Trivialiteitswet van Parkinson".into()),
+        );
+        assert_eq!(
+            langlinks
+                .iter()
+                .filter(|ll| ll.lang == "fr".to_owned())
+                .next()
+                .unwrap()
+                .title,
+            Some("Loi de futilité de Parkinson".into()),
+        );
+    }
+
+    #[test]
     fn categories() {
         let mut wikipedia = w();
         wikipedia.categories_results = "3".to_owned();


### PR DESCRIPTION
This PR adds the ability to fetch language links for a given `Page`, which can be iterated over. These language links returned by Wikipedia define in what languages a page is available. Each item holds the language tag and the page title in the specified language.

See: https://www.mediawiki.org/wiki/API:Langlinks