### PR TITLE
Update dependencies for newer OpenSSL support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = ["http-client"]
 http-client = ["reqwest", "url"]
 
 [dependencies]
-serde_json = "1.0.8"
-reqwest = { version = "0.8.1", optional = true }
-url = { version = "1.6.0", optional = true }
-failure = "0.1.1"
+serde_json = "1.0.35"
+reqwest = { version = "0.9.8", optional = true }
+url = { version = "1.7.2", optional = true }
+failure = "0.1.5"

--- a/src/http.rs
+++ b/src/http.rs
@@ -34,7 +34,7 @@ pub mod default {
             let url = reqwest::Url::parse_with_params(base_url, args)?;
             let client = reqwest::Client::new();
             let mut response = client.get(url)
-                .header(reqwest::header::UserAgent::new(self.user_agent.clone()))
+                .header(reqwest::header::USER_AGENT, self.user_agent.clone())
                 .send()?;
 
             ensure!(response.status().is_success(), err_msg("Bad status"));


### PR DESCRIPTION
This updates the crate dependencies to their newest available versions. This is required for supporting newer OpenSSL versions, such as version `1.1.1` that comes with `libssl-dev` on `Ubuntu 18.10`.

It would be awesome if you could also push this change to crates.io.