### PR TITLE
Modernize the repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = ["http-client"]
 http-client = ["reqwest", "url"]
 
 [dependencies]
-serde_json = "1.0.35"
+serde_json = "1.0.107"
 reqwest = { version = "0.11.20", optional = true, features = ["blocking"] }
 url = { version = "2.4.1", optional = true }
-failure = "0.1.5"
+failure = "0.1.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wikipedia"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["Sebastian Waisbrot <seppo0010@gmail.com>"]
 license-file = "LICENSE"
 description = "Access wikipedia articles from Rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "wikipedia"
 version = "0.3.3"
 authors = ["Sebastian Waisbrot <seppo0010@gmail.com>"]
 license-file = "LICENSE"
-
 description = "Access wikipedia articles from Rust"
 readme = "README.md"
 documentation = "https://seppo0010.github.io/wikipedia-rs/"
@@ -17,6 +16,6 @@ http-client = ["reqwest", "url"]
 
 [dependencies]
 serde_json = "1.0.35"
-reqwest = { version = "0.9.8", optional = true }
-url = { version = "1.7.2", optional = true }
+reqwest = { version = "0.11.20", optional = true, features = ["blocking"] }
+url = { version = "2.4.1", optional = true }
 failure = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Sebastian Waisbrot <seppo0010@gmail.com>"]
 license-file = "LICENSE"
 description = "Access wikipedia articles from Rust"
 readme = "README.md"
+edition = "2021"
 documentation = "https://seppo0010.github.io/wikipedia-rs/"
 
 repository = "https://github.com/seppo0010/wikipedia-rs/"

--- a/src/http.rs
+++ b/src/http.rs
@@ -3,14 +3,15 @@ pub use failure::Error;
 pub trait HttpClient {
     fn user_agent(&mut self, user_agent: String);
     fn get<'a, I>(&self, base_url: &str, args: I) -> Result<String, Error>
-        where I: Iterator<Item=(&'a str, &'a str)>;
+    where
+        I: Iterator<Item = (&'a str, &'a str)>;
 }
 
-#[cfg(feature="http-client")]
+#[cfg(feature = "http-client")]
 pub mod default {
-    use std::io::Read;
-    use reqwest;
     use failure::err_msg;
+    use reqwest;
+    use std::io::Read;
 
     use super::{Error, HttpClient};
 
@@ -20,7 +21,9 @@ pub mod default {
 
     impl Default for Client {
         fn default() -> Self {
-            Client { user_agent: "".to_owned() }
+            Client {
+                user_agent: "".to_owned(),
+            }
         }
     }
 
@@ -30,10 +33,13 @@ pub mod default {
         }
 
         fn get<'a, I>(&self, base_url: &str, args: I) -> Result<String, Error>
-                where I: Iterator<Item=(&'a str, &'a str)> {
+        where
+            I: Iterator<Item = (&'a str, &'a str)>,
+        {
             let url = reqwest::Url::parse_with_params(base_url, args)?;
-            let client = reqwest::Client::new();
-            let mut response = client.get(url)
+            let client = reqwest::blocking::Client::new();
+            let mut response = client
+                .get(url)
                 .header(reqwest::header::USER_AGENT, self.user_agent.clone())
                 .send()?;
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -14,7 +14,7 @@ pub struct Iter<'a, A: 'a + http::HttpClient, B: IterItem> {
 
 impl<'a, A: http::HttpClient, B: IterItem> Iter<'a, A, B> {
     pub fn new(page: &'a Page<A>) -> Result<Iter<'a, A, B>> {
-        let (array, cont) = try!(B::request_next(page, &None));
+        let (array, cont) = B::request_next(page, &None)?;
         Ok(Iter {
             page: page,
             inner: array.into_iter(),
@@ -25,7 +25,7 @@ impl<'a, A: http::HttpClient, B: IterItem> Iter<'a, A, B> {
 
     fn fetch_next(&mut self) -> Result <()> {
         if self.cont.is_some() {
-            let (array, cont) = try!(B::request_next(self.page, &self.cont));
+            let (array, cont) = B::request_next(self.page, &self.cont)?;
             self.inner = array.into_iter();
             self.cont = cont;
         }


### PR DESCRIPTION
Essentially:

- update dependencies & make them compile
    - all dependencies are updated to the latest known version
        - this fixes many noted security vulnerabilities in the dependencies
        - `2 critical, 3 high, 9 moderate, 1 low`
    - reqwest had to enable the `blocking` feature
        - `let client = reqwest::blocking::Client::new();`
- rust 2021 edition
    - replace try! macro with ? operator

- bump version to 0.4.0

I also accidentally ran `cargo fmt` on `src/http.rs`, sorry about that.
 The meat is `let client = reqwest::blocking::Client::new();`

All tests pass except for these three integration tests - but they also fail on the current `master`:

```
failures:
    tests::section_content
    tests::sections
    tests::sections2
```