### PR TITLE
Various fixes and enhancements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = ["http-client"]
 http-client = ["reqwest", "url"]
 
 [dependencies]
-serde_json = "1.0.107"
-reqwest = { version = "0.11.20", optional = true, features = ["blocking"] }
-url = { version = "2.4.1", optional = true }
-failure = "0.1.8"
+serde_json = "1.0.138"
+reqwest = { version = "0.12.2", optional = true, features = ["blocking"] }
+url = { version = "2.5.4", optional = true }
+thiserror = "2.0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wikipedia"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Sebastian Waisbrot <seppo0010@gmail.com>"]
 license-file = "LICENSE"
 description = "Access wikipedia articles from Rust"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The crate is called `wikipedia` and you can depend on it via cargo:
 
 ```toml
 [dependencies]
-wikipedia = "0.3.1"
+wikipedia = "0.5.0"
 ```
 
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -41,8 +41,8 @@ pub mod default {
         where
             I: Iterator<Item = (&'a str, &'a str)>,
         {
-            let url = reqwest::Url::parse_with_params(base_url, args)
-                .map_err(|_| Error::URLError)?;
+            let url =
+                reqwest::Url::parse_with_params(base_url, args).map_err(|_| Error::URLError)?;
             let client = reqwest::blocking::Client::new();
             let mut response = client
                 .get(url)

--- a/src/http.rs
+++ b/src/http.rs
@@ -29,7 +29,7 @@ pub mod default {
     impl Default for Client {
         fn default() -> Self {
             Client {
-                user_agent: "".to_owned(),
+                user_agent: "wikipedia (https://github.com/seppo0010/wikipedia-rs)".to_owned(),
                 bearer_token: None,
             }
         }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,7 +1,14 @@
 pub use crate::Error;
 
 pub trait HttpClient {
+    /// Set the user agent. Default user agent is empty string.
     fn user_agent(&mut self, user_agent: String);
+
+    /// Set a Wikimedia Personal API authentication token.
+    fn bearer_token(&mut self, bearer_token: String);
+
+    /// Run an http request with the given url and args, returning
+    /// the result as a string.
     fn get<'a, I>(&self, base_url: &str, args: I) -> Result<String, Error>
     where
         I: Iterator<Item = (&'a str, &'a str)>;
@@ -16,12 +23,14 @@ pub mod default {
 
     pub struct Client {
         user_agent: String,
+        bearer_token: Option<String>,
     }
 
     impl Default for Client {
         fn default() -> Self {
             Client {
                 user_agent: "".to_owned(),
+                bearer_token: None,
             }
         }
     }
@@ -37,18 +46,26 @@ pub mod default {
             self.user_agent = user_agent;
         }
 
+        fn bearer_token(&mut self, bearer_token: String) {
+            self.bearer_token = Some(bearer_token);
+        }
+
         fn get<'a, I>(&self, base_url: &str, args: I) -> Result<String, Error>
         where
             I: Iterator<Item = (&'a str, &'a str)>,
         {
             let url =
                 reqwest::Url::parse_with_params(base_url, args).map_err(|_| Error::URLError)?;
-            let client = reqwest::blocking::Client::new();
-            let mut response = client
+            let mut request = reqwest::blocking::Client::new()
                 .get(url)
-                .header(reqwest::header::USER_AGENT, self.user_agent.clone())
-                .send()?
-                .error_for_status()?;
+                .header(reqwest::header::USER_AGENT, self.user_agent.clone());
+            if let Some(ref bearer_token) = self.bearer_token {
+                request = request.header(
+                    reqwest::header::AUTHORIZATION,
+                    format!("Bearer {}", bearer_token),
+                );
+            }
+            let mut response = request.send()?.error_for_status()?;
 
             let mut response_str = String::new();
             response.read_to_string(&mut response_str)?;

--- a/src/http.rs
+++ b/src/http.rs
@@ -26,6 +26,12 @@ pub mod default {
         }
     }
 
+    impl From<reqwest::Error> for Error {
+        fn from(e: reqwest::Error) -> Error {
+            Error::HTTPError(Box::new(e))
+        }
+    }
+
     impl HttpClient for Client {
         fn user_agent(&mut self, user_agent: String) {
             self.user_agent = user_agent;
@@ -41,12 +47,8 @@ pub mod default {
             let mut response = client
                 .get(url)
                 .header(reqwest::header::USER_AGENT, self.user_agent.clone())
-                .send()
-                .map_err(|_| Error::HTTPError)?;
-
-            if !response.status().is_success() {
-                return Err(Error::HTTPError);
-            }
+                .send()?
+                .error_for_status()?;
 
             let mut response_str = String::new();
             response.read_to_string(&mut response_str)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -848,6 +848,7 @@ mod test {
     struct MockClient {
         pub url: Mutex<Vec<String>>,
         pub user_agent: Option<String>,
+        pub bearer_token: Option<String>,
         pub arguments: Mutex<Vec<iter::IterElems>>,
         pub response: Mutex<Vec<String>>,
     }
@@ -857,6 +858,7 @@ mod test {
             MockClient {
                 url: Mutex::new(Vec::new()),
                 user_agent: None,
+                bearer_token: None,
                 arguments: Mutex::new(Vec::new()),
                 response: Mutex::new(Vec::new()),
             }
@@ -866,6 +868,10 @@ mod test {
     impl super::http::HttpClient for MockClient {
         fn user_agent(&mut self, user_agent: String) {
             self.user_agent = Some(user_agent)
+        }
+
+        fn bearer_token(&mut self, bearer_token: String) {
+            self.bearer_token = Some(bearer_token)
         }
 
         fn get<'a, I>(&self, base_url: &str, args: I) -> Result<String, super::http::Error>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub enum Error {
     URLError,
     /// Some error communicating with the server
     #[error("HTTP Error")]
-    HTTPError,
+    HTTPError(#[from] Box<dyn std::error::Error>),
     /// Error reading response
     #[error("IO Error: {0}")]
     IOError(#[from] io::Error),
@@ -215,7 +215,7 @@ impl<A: http::HttpClient> Wikipedia<A> {
 
     fn query<'a, I>(&self, args: I) -> Result<serde_json::Value>
             where I: Iterator<Item=(&'a str, &'a str)> {
-        let response_str = self.client.get(&self.base_url(), args).map_err(|_| Error::HTTPError)?;
+        let response_str = self.client.get(&self.base_url(), args)?;
         let json = serde_json::from_str(&response_str).map_err(Error::JSONError)?;
         Ok(json)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,8 +143,7 @@ impl<A: http::HttpClient + Clone> Clone for Wikipedia<A> {
 
 impl<A: http::HttpClient> Wikipedia<A> {
     /// Creates a new object using the provided client and default values.
-    pub fn new(mut client: A) -> Self {
-        client.user_agent("wikipedia (https://github.com/seppo0010/wikipedia-rs)".to_owned());
+    pub fn new(client: A) -> Self {
         Wikipedia {
             client,
             pre_language_url: "https://".to_owned(),
@@ -845,6 +844,8 @@ mod test {
     use super::Wikipedia;
     use std::sync::Mutex;
 
+    const DEFAULT_AGENT: &str = "wikipedia (https://github.com/seppo0010/wikipedia-rs)";
+
     struct MockClient {
         pub url: Mutex<Vec<String>>,
         pub user_agent: Option<String>,
@@ -857,7 +858,7 @@ mod test {
         fn default() -> Self {
             MockClient {
                 url: Mutex::new(Vec::new()),
-                user_agent: None,
+                user_agent: Some(DEFAULT_AGENT.into()),
                 bearer_token: None,
                 arguments: Mutex::new(Vec::new()),
                 response: Mutex::new(Vec::new()),
@@ -911,10 +912,7 @@ mod test {
             .unwrap()
             .push("{}".to_owned());
         wikipedia.search("hello world").unwrap_err();
-        assert_eq!(
-            &*wikipedia.client.user_agent.unwrap(),
-            "wikipedia (https://github.com/seppo0010/wikipedia-rs)"
-        );
+        assert_eq!(&*wikipedia.client.user_agent.unwrap(), DEFAULT_AGENT);
 
         let mut client = MockClient::default();
         client.user_agent("hello world".to_owned());

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -21,9 +21,10 @@ mod tests {
     #[test]
     fn geosearch() {
         let wikipedia = w();
-        let results = wikipedia.geosearch(-34.603333, -58.381667, 10).unwrap();
+        let results = wikipedia.geosearch(-34.607307, -58.445566, 1000).unwrap();
         assert!(!results.is_empty());
-        assert!(results.contains(&"Buenos Aires".to_owned()));
+        eprintln!("{:?}", results);
+        assert!(results.contains(&"Villa Crespo".to_owned()));
     }
 
     #[test]
@@ -216,7 +217,6 @@ mod tests {
                 page.get_sections().unwrap(),
                 vec![
                 "Argument".to_owned(),
-                "Examples".to_owned(),
                 "Related principles and formulations".to_owned(),
                 "See also".to_owned(),
                 "References".to_owned(),
@@ -234,7 +234,6 @@ mod tests {
                 page.get_sections().unwrap(),
                 vec![
                 "Argument".to_owned(),
-                "Examples".to_owned(),
                 "Related principles and formulations".to_owned(),
                 "See also".to_owned(),
                 "References".to_owned(),
@@ -248,8 +247,8 @@ mod tests {
     fn section_content() {
         let wikipedia = w();
         let page = wikipedia.page_from_pageid("4138548".to_owned());
-        assert!(page.get_section_content("Examples").unwrap().unwrap()
-                .contains("finance committee meeting"))
+        assert!(page.get_section_content("Argument").unwrap().unwrap()
+                .contains("reactor is so vastly expensive"))
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14,7 +14,7 @@ mod tests {
     fn search() {
         let wikipedia = w();
         let results = wikipedia.search("hello world").unwrap();
-        assert!(results.len() > 0);
+        assert!(!results.is_empty());
         assert!(results.contains(&"\"Hello, World!\" program".to_owned()));
     }
 
@@ -22,7 +22,7 @@ mod tests {
     fn geosearch() {
         let wikipedia = w();
         let results = wikipedia.geosearch(-34.603333, -58.381667, 10).unwrap();
-        assert!(results.len() > 0);
+        assert!(!results.is_empty());
         assert!(results.contains(&"Buenos Aires".to_owned()));
     }
 
@@ -103,9 +103,9 @@ mod tests {
         let mut c = 0;
         let mut set = HashSet::new();
         for i in images {
-            assert!(i.title.len() > 0);
-            assert!(i.url.len() > 0);
-            assert!(i.description_url.len() > 0);
+            assert!(!i.title.is_empty());
+            assert!(!i.url.is_empty());
+            assert!(!i.description_url.is_empty());
             c += 1;
             set.insert(i.title);
             if c == 11 {
@@ -176,18 +176,14 @@ mod tests {
         let langlinks = page.get_langlinks().unwrap().collect::<Vec<_>>();
         assert_eq!(
             langlinks
-                .iter()
-                .filter(|ll| ll.lang == "nl".to_owned())
-                .next()
+                .iter().find(|ll| ll.lang == *"nl")
                 .unwrap()
                 .title,
             Some("Trivialiteitswet van Parkinson".into()),
         );
         assert_eq!(
             langlinks
-                .iter()
-                .filter(|ll| ll.lang == "fr".to_owned())
-                .next()
+                .iter().find(|ll| ll.lang == *"fr")
                 .unwrap()
                 .title,
             Some("Loi de futilité de Parkinson".into()),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2,9 +2,9 @@ extern crate wikipedia;
 
 #[cfg(feature = "http-client")]
 mod tests {
-    use wikipedia::Wikipedia;
-    use wikipedia::http;
     use std::collections::HashSet;
+    use wikipedia::http;
+    use wikipedia::Wikipedia;
 
     fn w() -> Wikipedia<http::default::Client> {
         Wikipedia::default()
@@ -50,7 +50,10 @@ mod tests {
     fn title() {
         let wikipedia = w();
         let page = wikipedia.page_from_title("Parkinson's law of triviality".to_owned());
-        assert_eq!(page.get_title().unwrap(), "Parkinson's law of triviality".to_owned());
+        assert_eq!(
+            page.get_title().unwrap(),
+            "Parkinson's law of triviality".to_owned()
+        );
         let page = wikipedia.page_from_pageid("4138548".to_owned());
         assert_eq!(page.get_title().unwrap(), "Law of triviality".to_owned());
     }
@@ -176,17 +179,11 @@ mod tests {
         let page = wikipedia.page_from_title("Law of triviality".to_owned());
         let langlinks = page.get_langlinks().unwrap().collect::<Vec<_>>();
         assert_eq!(
-            langlinks
-                .iter().find(|ll| ll.lang == *"nl")
-                .unwrap()
-                .title,
+            langlinks.iter().find(|ll| ll.lang == *"nl").unwrap().title,
             Some("Trivialiteitswet van Parkinson".into()),
         );
         assert_eq!(
-            langlinks
-                .iter().find(|ll| ll.lang == *"fr")
-                .unwrap()
-                .title,
+            langlinks.iter().find(|ll| ll.lang == *"fr").unwrap().title,
             Some("Loi de futilité de Parkinson".into()),
         );
     }
@@ -214,16 +211,16 @@ mod tests {
         let wikipedia = w();
         let page = wikipedia.page_from_title("Bikeshedding".to_owned());
         assert_eq!(
-                page.get_sections().unwrap(),
-                vec![
+            page.get_sections().unwrap(),
+            vec![
                 "Argument".to_owned(),
                 "Related principles and formulations".to_owned(),
                 "See also".to_owned(),
                 "References".to_owned(),
                 "Further reading".to_owned(),
                 "External links".to_owned(),
-                ]
-                )
+            ]
+        )
     }
 
     #[test]
@@ -231,24 +228,27 @@ mod tests {
         let wikipedia = w();
         let page = wikipedia.page_from_pageid("4138548".to_owned());
         assert_eq!(
-                page.get_sections().unwrap(),
-                vec![
+            page.get_sections().unwrap(),
+            vec![
                 "Argument".to_owned(),
                 "Related principles and formulations".to_owned(),
                 "See also".to_owned(),
                 "References".to_owned(),
                 "Further reading".to_owned(),
                 "External links".to_owned(),
-                ]
-                )
+            ]
+        )
     }
 
     #[test]
     fn section_content() {
         let wikipedia = w();
         let page = wikipedia.page_from_pageid("4138548".to_owned());
-        assert!(page.get_section_content("Argument").unwrap().unwrap()
-                .contains("reactor is so vastly expensive"))
+        assert!(page
+            .get_section_content("Argument")
+            .unwrap()
+            .unwrap()
+            .contains("reactor is so vastly expensive"))
     }
 
     #[test]


### PR DESCRIPTION
These commits bring the code up to date with the ecosystem and provide some enhancements.

* Moved error crate from `failure` to `thiserror`, as `failure` is no longer much-maintained and was missing a needed feature.
* Bumped all crate dependencies to their latest version.
* Added support for authentication via Wikimedia Personal API token.
* Made HTTP error returns carry error information.
* Moved defaulting of User Agent to client from wrapper.
* Fixed some failing tests for now — see Issue #14.
* Made everything pass Rustfmt and Clippy.

Bumped to version 0.5.0 because of small breaking changes:

* `Error::HTTPError` now carries an error field.
* Bearer token override added to `HttpClient` trait.
* `Error` enum no longer implements `failure::Fail`.

Closes Issue #13.